### PR TITLE
Using ga.js instead of deprecated _gaq

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/spec               export-ignore
+/phpspec.yml
+/.travis.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/bin/
 /vendor/
 /nbproject/
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+before_script:
+    - composer install --dev -v --prefer-source
+
+script:
+    - bin/phpspec run -fpretty --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.0.0] - 2015-07-23
+### BC Break
+- Using Universal Analytics `ga()` syntax instead of deprecated older Google Analytics `_gaq` syntax.
+- "total" key in ecommerce tracker's addTransaction has been replaced with "revenue" which should contain the total profit ([read more](http://misterphilip.com/universal-analytics/migration/ecommerce))
+- "city", "state" and "country" in ecommerce's tracker addTransaction are not used in the new API, they should be removed from `EcommerceTracker::addTrans` calls. 
+
+### Added
+- new `Analytics` wrapper that will print the google snippets along with all the trackers's call.
+
+## [0.1] Initial release with _gaq syntax

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# google-analytics
-Tracking events and ecommerce with google analytics
+# betacie/google-analytics
+
+Tracking events and e-commerce with google analytics
 
 ```php
 <?php
@@ -46,4 +47,3 @@ You could defined Storage and Tracker as Symfony service and inject them in othe
     <argument type="service" id="betacie_google.tracking_bag" />
 </service>
 ```
-

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,11 @@
         "psr-4": {
             "Betacie\\Google\\": "src/"
         }
+    },
+    "config": {
+        "bin-dir": "bin"
+    },
+    "require-dev": {
+        "phpspec/phpspec": "^2.2"
     }
 }

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,4 @@
+suites:
+    google_analytics:
+        namespace: Betacie\Google
+        psr4_prefix: Betacie\Google

--- a/spec/AnalyticsSpec.php
+++ b/spec/AnalyticsSpec.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace spec\Betacie\Google;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Betacie\Google\Tracker\TrackerInterface;
+
+class AnalyticsSpec extends ObjectBehavior
+{
+    function let(TrackerInterface $tracker)
+    {
+        $this->beConstructedWith('UA-XXXX-Y', $tracker);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Betacie\Google\Analytics');
+    }
+
+    function it_checks_if_tracking_id_is_set($tracker)
+    {
+        $this
+            ->shouldThrow(new \InvalidArgumentException('Parameter "%betacie_google.analytics.tracking_id%" has not been set.'))
+            ->during('__construct', [null, $tracker])
+        ;
+    }
+
+    function it_has_a_tracker($tracker)
+    {
+        $this->getTracker()->shouldReturn($tracker);
+    }
+
+    function it_renders_the_entire_google_analytics($tracker)
+    {
+        $tracker->render()->willReturn('ga("somecalls");'.PHP_EOL);
+
+        $this->render()->shouldReturn(
+             '(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,"script","//www.google-analytics.com/analytics.js","ga");'.PHP_EOL
+            .'ga("create", "UA-XXXX-Y", "auto");'.PHP_EOL
+            .'ga("send", "pageview");'.PHP_EOL
+            .'ga("somecalls");'.PHP_EOL
+        );
+    }
+
+    function it_renders_the_global_object()
+    {
+        $this->renderGlobalObject()->shouldReturn(
+            '(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,"script","//www.google-analytics.com/analytics.js","ga");'.PHP_EOL
+        );
+    }
+
+    function it_renders_the_create_account()
+    {
+        $this->renderCreateAccount()->shouldReturn('ga("create", "UA-XXXX-Y", "auto");'.PHP_EOL);
+    }
+
+    function it_renders_a_page_view()
+    {
+        $this->renderPageView()->shouldReturn('ga("send", "pageview");'.PHP_EOL);
+    }
+}

--- a/spec/Tracker/EcommerceTrackerSpec.php
+++ b/spec/Tracker/EcommerceTrackerSpec.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace spec\Betacie\Google\Tracker;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Betacie\Google\Storage\StorageInterface;
+
+class EcommerceTrackerSpec extends ObjectBehavior
+{
+    function let(StorageInterface $storage)
+    {
+        $this->beConstructedWith($storage);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Betacie\Google\Tracker\EcommerceTracker');
+        $this->shouldImplement('Betacie\Google\Tracker\TrackerInterface');
+    }
+
+    function it_renders_add_transaction()
+    {
+        $this->renderAddTransaction([
+            'transactionId' => '1234',
+            'affiliation' => 'FooAffiliation',
+            'revenue' => 23.50,
+            'tax' => 4.5,
+            'shipping' => 10,
+        ])->shouldReturn('ga("ecommerce:addTransaction",{"id":"1234","affiliation":"FooAffiliation","revenue":23.5,"tax":4.5,"shipping":10});'.PHP_EOL);
+    }
+
+    function it_renders_add_item()
+    {
+        $this->renderAddItem([
+            'transactionId' => '1234',
+            'sku' => 'TSHIRT',
+            'name' => 'Hello Kitty',
+            'category' => 'Clothing',
+            'price' => 19.99,
+            'quantity' => 2,
+        ])->shouldReturn('ga("ecommerce:addItem",{"id":"1234","name":"Hello Kitty","sku":"TSHIRT","category":"Clothing","price":19.99,"quantity":2});'.PHP_EOL);
+    }
+
+    function it_renders_the_sent_transaction()
+    {
+        $this->renderSendTransaction()->shouldReturn('ga("ecommerce:send");'.PHP_EOL);
+    }
+
+    function it_renders_all_stored_calls($storage)
+    {
+        //add one transaction
+        $storage->get('_addTrans', [])->willReturn([[
+            'transactionId' => '1234',
+            'revenue' => 23.50,
+        ]]);
+        $storage->clear('_addTrans')->shouldBeCalled();
+        
+        //add two items
+        $storage->get('_addItem', [])->willReturn([
+            [
+                'transactionId' => '1234',
+                'name' => 'Hello Kitty',
+            ],
+            [
+                'transactionId' => '1234',
+                'name' => 'Nirvana',
+            ]
+        ]);
+        $storage->clear('_addItem')->shouldBeCalled();
+
+        //send transaction
+        $storage->get('_trackTrans', false)->willReturn(true);
+        $storage->clear('_trackTrans')->shouldBeCalled();
+
+        $this->render()->shouldReturn(
+             'ga("ecommerce:addTransaction",{"id":"1234","revenue":23.5});'.PHP_EOL
+            .'ga("ecommerce:addItem",{"id":"1234","name":"Hello Kitty"});'.PHP_EOL
+            .'ga("ecommerce:addItem",{"id":"1234","name":"Nirvana"});'.PHP_EOL
+            .'ga("ecommerce:send");'.PHP_EOL
+        );
+    }
+}

--- a/spec/Tracker/EventTrackerSpec.php
+++ b/spec/Tracker/EventTrackerSpec.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace spec\Betacie\Google\Tracker;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Betacie\Google\Storage\StorageInterface;
+use Betacie\Google\Tracker\EventTracker;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+
+class EventTrackerSpec extends ObjectBehavior
+{
+    function let(StorageInterface $storage)
+    {
+        $this->beConstructedWith($storage);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Betacie\Google\Tracker\EventTracker');
+        $this->shouldImplement('Betacie\Google\Tracker\TrackerInterface');
+    }
+
+    function it_can_track_an_event($storage)
+    {
+        $this->shouldThrow(new MissingOptionsException('The required options "action", "category" are missing.'))->duringTrackEvent([]);
+        
+        $this->shouldThrow(new UndefinedOptionsException('The option "foo" does not exist. Defined options are: "action", "category", "label", "noninteraction", "value".'))->duringTrackEvent([
+            'category' => 'Cat1',
+            'action' => 'Action1',
+            'foo' => 'bar'
+        ]);
+
+        $storage->track('_trackEvent', [
+            'category' => 'MyCategory1',
+            'action' => 'MyAction1',
+            'label' => 'MyLabel1',
+            'value' => 'Foobar1',
+            'noninteraction' => true
+        ])->shouldBeCalled();
+
+        $this->trackEvent([
+            'category' => 'MyCategory1',
+            'action' => 'MyAction1',
+            'label' => 'MyLabel1',
+            'value' => 'Foobar1',
+            'noninteraction' => true
+        ]);
+
+        //minimum requirements
+        $storage->track('_trackEvent', [
+            'category' => 'MyCategory1',
+            'action' => 'MyAction1',
+            'label' => null,
+            'value' => null,
+            'noninteraction' => null
+        ])->shouldBeCalled();
+
+        $this->trackEvent([
+            'category' => 'MyCategory1',
+            'action' => 'MyAction1',
+        ]);
+    }
+
+    function it_renders_all_events($storage)
+    {
+        $events = [
+            [
+                'category' => 'MyCategory1',
+                'action' => 'MyAction1',
+                'label' => 'MyLabel1',
+                'value' => 'Foobar1',
+                'noninteraction' => true
+            ],
+            [
+                'category' => 'MyCategory2',
+                'action' => 'MyAction2',
+                'label' => 'MyLabel2',
+                'value' => 'Foobar2',
+                'noninteraction' => false
+            ]
+        ];
+
+        $storage->get('_trackEvent', [])->willReturn($events);
+
+        $storage->clear('_trackEvent')->shouldBeCalled();
+
+        $gaEvents  = 'ga("send","event","MyCategory1","MyAction1",{"eventLabel":"MyLabel1","eventValue":"Foobar1","nonInteraction":true});'.PHP_EOL;
+        $gaEvents .= 'ga("send","event","MyCategory2","MyAction2",{"eventLabel":"MyLabel2","eventValue":"Foobar2","nonInteraction":false});'.PHP_EOL;
+
+        $this->render()->shouldReturn($gaEvents);
+    }
+
+    function it_renders_an_event()
+    {
+        $this->renderEvent([
+            'category' => 'MyCategory',
+            'action' => 'MyAction',
+            'label' => null,
+            'value' => null,
+            'noninteraction' => null
+        ])->shouldReturn(
+            'ga("send","event","MyCategory","MyAction",[]);'.PHP_EOL
+        );
+    }
+}

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Betacie\Google;
+
+use Betacie\Google\Tracker\TrackerInterface;
+
+class Analytics
+{
+    protected $trackingId;
+    protected $tracker;
+
+    public function __construct($trackingId, TrackerInterface $tracker)
+    {
+        if (!$trackingId) {
+            throw new \InvalidArgumentException('Parameter "%betacie_google.analytics.tracking_id%" has not been set.');
+        }
+
+        $this->trackingId = $trackingId;
+        $this->tracker = $tracker;
+    }
+
+    public function getTracker()
+    {
+        return $this->tracker;
+    }
+
+    public function render()
+    {
+        return $this->renderGlobalObject()
+            .$this->renderCreateAccount()
+            .$this->renderPageView()
+            .$this->tracker->render()
+        ;
+    }
+
+    public function renderGlobalObject()
+    {
+        return '(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,"script","//www.google-analytics.com/analytics.js","ga");'.PHP_EOL;
+    }
+
+    public function renderCreateAccount()
+    {
+        return sprintf('ga("create", "%s", "auto");%s', $this->trackingId, PHP_EOL);
+    }
+
+    public function renderPageView()
+    {
+        return 'ga("send", "pageview");'.PHP_EOL;
+    }
+}


### PR DESCRIPTION
Things to do :
- [ ] Test addTrans / addItem methods
- [ ] Update README.md
- [ ] Replace `array_key_exists` by `isset` 
- [x] See if we can refactor more by adding a single entry point to tracking (instead of several different trackers and aggregate tracker)
- [ ] See if we can match Google's api with our array options
